### PR TITLE
Rename ReactiveOps to Fairwinds

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  author: ReactiveOps
+  author: Fairwinds
   description: OAuth proxy role.
-  company: ReactiveOps
+  company: Fairwinds
   license: license (GPLv2, CC-BY, etc)
   min_ansible_version: 1.2
   platforms:


### PR DESCRIPTION
Remaining mentions: 
```

```